### PR TITLE
Mark "hadoop" dependency as provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,13 @@ or `false` if it failed (Note: this API is not yet stable, and may throw excepti
 First, you need sbt 0.12.1 and scala 2.9.1 or scala 2.10.0. To build scamr as a library and install it to your local ivy cache, run:
 
 ```bash
-sbt package && sbt publish-local
+sbt publish-local
+```
+
+To publish for both 2.9.1 and 2.10.0, do
+
+```bash
+sbt "+ publish-local"
 ```
 
 To build a "fat jar" that you can use to run the examples, run `sbt assembly`. This will create a self-contained jar that can be run locally or on a hadoop cluster at `target/scamr-examples.jar`.

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ version := "0.1.6-SNAPSHOT"
 
 scalaVersion := "2.9.1"
 
+crossScalaVersions := Seq("2.9.1", "2.10.0")
+
 // sbt defaults to <project>/src/test/{scala,java} unless we put this in
 unmanagedSourceDirectories in Test <<= Seq(baseDirectory(_ / "src" / "test")).join
 


### PR DESCRIPTION
There's no need to pull in the hadoop dependency as Hadoop is always provided when you run jobs.  Excluding jars in assembly is error prone and forces downstream MR jobs to exclude the same jars.  A much better solution is to mark the hadoop dep as "provided" which means it won't be pulled in transitivitely by users of ScaMR.  It also removes the need to exclude jars in assembly.

Also I added the easy ability to publish both 2.9.1 and 2.10.0 artifacts.
