### PR TITLE
Created an override option for the default sequence file link

### DIFF
--- a/src/main/scala/scamr/io/InputOutput.scala
+++ b/src/main/scala/scamr/io/InputOutput.scala
@@ -69,15 +69,6 @@ object InputOutput {
     def this(outputFormatClass: Class[_ <: OutputFormat[K, V]], outputDir: String)
             (implicit km: Manifest[K], vm: Manifest[V]) = this(outputFormatClass, new Path(outputDir))(km, vm)
 
-    // The key and value types must be Writable so they can be written to the job output files.
-    // Unfortunately this check happens at runtime rather than compile time. The reason is that we can't
-    // expect all MR jobs to produce Writable key/value types - some OutputFormats (for example, Cassandra)
-    // take non-Writable key/value types and store them outside of HDFS using their own storage mechanism.
-    // Although this check happens at runtime, at least it happens during the job configuration stage, before
-    // any jobs are launched.
-    mustBeWritable(km, "Key class")
-    mustBeWritable(vm, "Value class")
-
     override def configureOutput(job: Job) {
       super.configureOutput(job)
       FileOutputFormat.setOutputPath(job, outputDir)
@@ -87,11 +78,17 @@ object InputOutput {
   class TextFileSink[K, V](outputDir: Path)(implicit km: Manifest[K], vm: Manifest[V])
   extends FileSink[K, V](classOf[TextOutputFormat[K, V]], outputDir) {
 
+    mustBeWritable(km, "Key class")
+    mustBeWritable(vm, "Value class")
+
     def this(outputDir: String)(implicit km: Manifest[K], vm: Manifest[V]) = this(new Path(outputDir))(km, vm)
   }
 
   class SequenceFileSink[K, V](outputDir: Path)(implicit km: Manifest[K], vm: Manifest[V])
   extends FileSink[K, V](classOf[SequenceFileOutputFormat[K, V]], outputDir) {
+
+    mustBeWritable(km, "Key class")
+    mustBeWritable(vm, "Value class")
 
     def this(outputDir: String)(implicit km: Manifest[K], vm: Manifest[V]) = this(new Path(outputDir))(km, vm)
   }
@@ -105,15 +102,6 @@ object InputOutput {
                                 val workingDir: Path)
                                (implicit km: Manifest[K], vm: Manifest[V])
   extends Link[K, V] {
-
-    // The key and value types must be Writable so they can be written to the intermediate sequence files.
-    // Unfortunately this check happens at runtime rather than compile time. The reason is that we can't
-    // expect all MR jobs to produce Writable key/value types - some OutputFormats (for example, Cassandra)
-    // take non-Writable key/value types and store them outside of HDFS using their own storage mechanism.
-    // Although this check happens at runtime, at least it happens during the job configuration stage, before
-    // any jobs are launched.
-    mustBeWritable(km, "Key class")
-    mustBeWritable(vm, "Value class")
 
     override def configureOutput(producerJob: Job) {
       super.configureOutput(producerJob)
@@ -165,7 +153,15 @@ object InputOutput {
   }
 
   class SequenceFileLink[K, V](workingDir: Path)(implicit km: Manifest[K], vm: Manifest[V])
-  extends FileLink[K, V](classOf[SequenceFileOutputFormat[K, V]], classOf[SequenceFileInputFormat[K, V]], workingDir)
+  extends FileLink[K, V](classOf[SequenceFileOutputFormat[K, V]], classOf[SequenceFileInputFormat[K, V]], workingDir) {
+
+    // The key and value types must be Writable so they can be written to the intermediate sequence files.
+    // Unfortunately this check happens at runtime rather than compile time.
+
+    mustBeWritable(km, "Key class")
+    mustBeWritable(vm, "Value class")
+
+  }
 
   def mustBeWritable[T](manifest: Manifest[T], messagePrefix: String) {
     val clazz = manifest.erasure.asInstanceOf[Class[T]]

--- a/src/main/scala/scamr/mapreduce/MapReducePipeline.scala
+++ b/src/main/scala/scamr/mapreduce/MapReducePipeline.scala
@@ -4,6 +4,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
 import scamr.conf.{ConfOrJobModifier, JobModifier, ConfModifier}
+import scamr.io.InputOutput.FileLink
 import scamr.io.{InputOutputUtils, InputOutput}
 
 class MapReducePipeline(protected val pipeline: MapReducePipeline.PublicExecutable) {
@@ -101,9 +102,9 @@ object MapReducePipeline {
     // wrapping them in a 0-ary closure.
     def -->(sinkGenerator: () => InputOutput.Sink[K2, V2]): MapReducePipeline = this --> sinkGenerator()
 
-    def -->[K3, V3](nextJob: MapReduceJob[K2, V2, _, _, K3, V3])
+    def -->[K3, V3](nextJob: MapReduceJob[K2, V2, _, _, K3, V3], link: Option[FileLink[K2, V2]] = None)
                    (implicit k3m: Manifest[K3], v3m: Manifest[V3]): JobStage[K2, V2, K3, V3] = {
-      val nextStage = new LinkStage[K2, V2](this, workingDir)(k2m, v2m)
+      val nextStage = new LinkStage[K2, V2](this, workingDir, link)(k2m, v2m)
       this.next = nextStage
       nextStage --> nextJob
     }
@@ -158,12 +159,15 @@ object MapReducePipeline {
     }
   }
 
-  class LinkStage[K, V](previous: Stage[_, _, K, V], val workingDir: Path)
+  class LinkStage[K, V](previous: Stage[_, _, K, V], val workingDir: Path, fileLink: Option[FileLink[K, V]] = None)
                        (implicit km: Manifest[K], vm: Manifest[V])
   extends Stage[K, V, K, V] with SourceLike[K, V] with SinkLike[K, V] {
 
     override val prev = previous.asInstanceOf[Stage[_, _, _ <: K, V]]
-    private val link = new InputOutput.SequenceFileLink[K, V](workingDir)
+    private val link: FileLink[K, V] = fileLink match {
+      case None => new InputOutput.SequenceFileLink[K, V](workingDir)
+      case Some(l) => l
+    }
     override val sink: InputOutput.Sink[K, V] = link
     override val source: InputOutput.Source[K, V] = link
     override val baseConfiguration = prev.baseConfiguration


### PR DESCRIPTION
Created an override option for the default sequence file link, so that one can write to different intermediary file types (ex. parquet) when chaining between two map-reduce jobs.

Took out the mustBeWritable checks to make this override work.  (ex. dont need to enforce Writable with Thrift/Parquet files).
